### PR TITLE
Add --random nonce option

### DIFF
--- a/cpu-miner.c
+++ b/cpu-miner.c
@@ -213,7 +213,7 @@ Options:\n\
       --no-stratum      disable X-Stratum support\n\
       --no-redirect     ignore requests to change the URL of the mining server\n\
   -q, --quiet           disable per-thread hashmeter output\n\
-  -e, --random		start with a random nonce\n\
+  -e, --random          start with a random nonce\n\
   -D, --debug           enable debug output\n\
   -P, --protocol-dump   verbose dump of protocol-level activities\n"
 #ifdef HAVE_SYSLOG_H

--- a/miner.h
+++ b/miner.h
@@ -186,6 +186,7 @@ struct work_restart {
 extern bool opt_debug;
 extern bool opt_protocol;
 extern bool opt_redirect;
+extern bool opt_random;
 extern int opt_timeout;
 extern bool want_longpoll;
 extern bool have_longpoll;


### PR DESCRIPTION
Make the different thread start with a random nonce.
Could add some randomness to the miner and/or avoid miners doing the exact same work.